### PR TITLE
Keep only the binary as artifact.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,20 +23,5 @@ on_failure:
   - appveyor PushArtifact failure.zip
 
 artifacts:
-  - path: '*.Rcheck\**\*.log'
-    name: Logs
-
-  - path: '*.Rcheck\**\*.out'
-    name: Logs
-
-  - path: '*.Rcheck\**\*.fail'
-    name: Logs
-
-  - path: '*.Rcheck\**\*.Rout'
-    name: Logs
-
-  - path: '\*_*.tar.gz'
-    name: Bits
-
   - path: '\*_*.zip'
     name: Bits


### PR DESCRIPTION
Only the zip file will be kept on AppVeyor.
